### PR TITLE
Feature/task 10 margin of nested eqipments

### DIFF
--- a/de.dlr.sc.virsat.model.extension.cef.test/src-gen/de/dlr/sc/virsat/model/extension/cef/migrator/AMigrator1v6Test.java
+++ b/de.dlr.sc.virsat.model.extension.cef.test/src-gen/de/dlr/sc/virsat/model/extension/cef/migrator/AMigrator1v6Test.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2019 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.extension.cef.migrator;
+
+// *****************************************************************
+// * Import Statements
+// *****************************************************************
+
+
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+
+// *****************************************************************
+// * Class Declaration
+// *****************************************************************
+
+import org.junit.Before;
+
+/**
+ * Auto Generated Abstract Generator Gap Class
+ * 
+ * Don't Manually modify this class
+ * 
+ * VirSat DLR CEF Concept
+ * 
+ */	
+public abstract class AMigrator1v6Test {
+	protected Concept conceptMigrateTo;
+	protected Concept conceptMigrateFromRepository;
+	protected Concept conceptMigrateFrom;
+	
+	@Before
+	public void setUp() throws Exception {
+		String conceptXmiPluginPathMigrateTo = "de.dlr.sc.virsat.model.extension.cef/concept/concept_v1_6.xmi";
+		String conceptXmiPluginPathMigrateFrom = "de.dlr.sc.virsat.model.extension.cef/concept/concept_v1_5.xmi";
+		
+		conceptMigrateTo = de.dlr.sc.virsat.concept.unittest.util.ConceptXmiLoader.loadConceptFromPlugin(conceptXmiPluginPathMigrateTo);
+		conceptMigrateFromRepository = de.dlr.sc.virsat.concept.unittest.util.ConceptXmiLoader.loadConceptFromPlugin(conceptXmiPluginPathMigrateFrom);
+		conceptMigrateFrom = EcoreUtil.copy(conceptMigrateFromRepository);
+	}
+}

--- a/de.dlr.sc.virsat.model.extension.cef.test/src-gen/de/dlr/sc/virsat/model/extension/cef/test/AllTestsGen.java
+++ b/de.dlr.sc.virsat.model.extension.cef.test/src-gen/de/dlr/sc/virsat/model/extension/cef/test/AllTestsGen.java
@@ -39,6 +39,7 @@ import de.dlr.sc.virsat.model.extension.cef.model.ValueTest;
 import de.dlr.sc.virsat.model.extension.cef.model.ParameterTest;
 import de.dlr.sc.virsat.model.extension.cef.migrator.Migrator1v2Test;
 import de.dlr.sc.virsat.model.extension.cef.migrator.Migrator1v1Test;
+import de.dlr.sc.virsat.model.extension.cef.migrator.Migrator1v6Test;
 import de.dlr.sc.virsat.model.extension.cef.model.EquipmentPowerParametersTest;
 import de.dlr.sc.virsat.model.extension.cef.migrator.Migrator1v3Test;
 import de.dlr.sc.virsat.model.extension.cef.model.DocumentTest;
@@ -76,6 +77,7 @@ import de.dlr.sc.virsat.model.extension.cef.model.EquipmentMassParametersTest;
 	Migrator1v3Test.class,
 	Migrator1v4Test.class,
 	Migrator1v5Test.class,
+	Migrator1v6Test.class,
 				})
 
 /**

--- a/de.dlr.sc.virsat.model.extension.cef.test/src/de/dlr/sc/virsat/model/extension/cef/migrator/Migrator1v6Test.java
+++ b/de.dlr.sc.virsat.model.extension.cef.test/src/de/dlr/sc/virsat/model/extension/cef/migrator/Migrator1v6Test.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2019 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.extension.cef.migrator;
+
+// *****************************************************************
+// * Import Statements
+// *****************************************************************
+
+
+import de.dlr.sc.virsat.model.dvlm.DVLMFactory;
+import de.dlr.sc.virsat.model.dvlm.Repository;
+
+// *****************************************************************
+// * Class Declaration
+// *****************************************************************
+
+import org.junit.Test;
+
+/**
+ * Auto Generated Class inheriting from Generator Gap Class
+ * 
+ * This class is generated once, do your changes here
+ * 
+ * VirSat DLR CEF Concept
+ * 
+ */
+public class Migrator1v6Test extends AMigrator1v6Test {		
+	
+	@Test
+	public void testMigrator1v6() {
+		Migrator1v6 testMigrator1v6 = new Migrator1v6();
+		
+		Repository repository = DVLMFactory.eINSTANCE.createRepository();
+		repository.getActiveConcepts().add(conceptMigrateFromRepository);
+		
+		testMigrator1v6.migrate(conceptMigrateFrom, conceptMigrateFromRepository, conceptMigrateTo);
+	}
+	
+}

--- a/de.dlr.sc.virsat.model.extension.cef/concept/concept.concept
+++ b/de.dlr.sc.virsat.model.extension.cef/concept/concept.concept
@@ -142,7 +142,7 @@ Concept de.dlr.sc.virsat.model.extension.cef displayname "CEF" version 1.6 descr
 		Type massTotalWithMargin of Category Parameter quantityKind "Mass" unit "Kilogram";
 		
 		Ref: massTotal = (massPerUnit + summary{massTotal, 1}) * EquipmentParameters.unitQuantity;
-		Ref: massTotalWithMargin = massPerUnit + (massPerUnit * EquipmentParameters.marginMaturity) + summary{massTotalWithMargin, 1};
+		Ref: massTotalWithMargin = (massPerUnit + (massPerUnit * EquipmentParameters.marginMaturity) + summary{massTotalWithMargin, 1}) * EquipmentParameters.unitQuantity;
 	}
 	
 	Category EquipmentPowerParameters {

--- a/de.dlr.sc.virsat.model.extension.cef/concept/concept.concept
+++ b/de.dlr.sc.virsat.model.extension.cef/concept/concept.concept
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-Concept de.dlr.sc.virsat.model.extension.cef displayname "CEF" version 1.5 description "VirSat DLR CEF Concept"
+Concept de.dlr.sc.virsat.model.extension.cef displayname "CEF" version 1.6 description "VirSat DLR CEF Concept"
 {
 	
 	
@@ -142,7 +142,7 @@ Concept de.dlr.sc.virsat.model.extension.cef displayname "CEF" version 1.5 descr
 		Type massTotalWithMargin of Category Parameter quantityKind "Mass" unit "Kilogram";
 		
 		Ref: massTotal = (massPerUnit + summary{massTotal, 1}) * EquipmentParameters.unitQuantity;
-		Ref: massTotalWithMargin = massTotal + (massTotal * EquipmentParameters.marginMaturity); 
+		Ref: massTotalWithMargin = massPerUnit + (massPerUnit * EquipmentParameters.marginMaturity) + summary{massTotalWithMargin, 1};
 	}
 	
 	Category EquipmentPowerParameters {

--- a/de.dlr.sc.virsat.model.extension.cef/concept/concept.xmi
+++ b/de.dlr.sc.virsat.model.extension.cef/concept/concept.xmi
@@ -172,17 +172,22 @@
       <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotal"/>
     </equationDefinitions>
     <equationDefinitions>
-      <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
-        <left xsi:type="dvlm_calc:AdditionAndSubtraction">
-          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
-          <right xsi:type="dvlm_calc:Parenthesis">
-            <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+      <expression xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+        <left xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:AdditionAndSubtraction">
+            <left xsi:type="dvlm_calc:AdditionAndSubtraction">
               <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
-              <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
-            </right>
+              <right xsi:type="dvlm_calc:Parenthesis">
+                <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+                  <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
+                  <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
+                </right>
+              </right>
+            </left>
+            <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
           </right>
         </left>
-        <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
+        <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.unitQuantity"/>
       </expression>
       <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin"/>
     </equationDefinitions>

--- a/de.dlr.sc.virsat.model.extension.cef/concept/concept.xmi
+++ b/de.dlr.sc.virsat.model.extension.cef/concept/concept.xmi
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<dvlm_c:Concept xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dvlm_c="http://www.virsat.sc.dlr.de/dvlm/v6/c" xmlns:dvlm_calc="http://www.virsat.sc.dlr.de/dvlm/v6/calc" xmlns:dvlm_cppd="http://www.virsat.sc.dlr.de/dvlm/v6/cp/cppd" name="de.dlr.sc.virsat.model.extension.cef" description="VirSat DLR CEF Concept" version="1.5" displayName="CEF">
+<dvlm_c:Concept xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dvlm_c="http://www.virsat.sc.dlr.de/dvlm/v6/c" xmlns:dvlm_calc="http://www.virsat.sc.dlr.de/dvlm/v6/calc" xmlns:dvlm_cppd="http://www.virsat.sc.dlr.de/dvlm/v6/cp/cppd" name="de.dlr.sc.virsat.model.extension.cef" description="VirSat DLR CEF Concept" version="1.6" displayName="CEF">
   <categories name="SystemMode" applicableFor="de.dlr.sc.virsat.model.extension.cef.System">
     <properties xsi:type="dvlm_cppd:StringProperty" name="note" description="A note for the mode" defaultValue="no description"/>
   </categories>
@@ -173,13 +173,16 @@
     </equationDefinitions>
     <equationDefinitions>
       <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
-        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotal"/>
-        <right xsi:type="dvlm_calc:Parenthesis">
-          <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
-            <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotal"/>
-            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
+        <left xsi:type="dvlm_calc:AdditionAndSubtraction">
+          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
+          <right xsi:type="dvlm_calc:Parenthesis">
+            <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+              <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
+              <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
+            </right>
           </right>
-        </right>
+        </left>
+        <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
       </expression>
       <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin"/>
     </equationDefinitions>

--- a/de.dlr.sc.virsat.model.extension.cef/concept/concept_v1_6.xmi
+++ b/de.dlr.sc.virsat.model.extension.cef/concept/concept_v1_6.xmi
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="ASCII"?>
+<dvlm_c:Concept xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dvlm_c="http://www.virsat.sc.dlr.de/dvlm/v6/c" xmlns:dvlm_calc="http://www.virsat.sc.dlr.de/dvlm/v6/calc" xmlns:dvlm_cppd="http://www.virsat.sc.dlr.de/dvlm/v6/cp/cppd" name="de.dlr.sc.virsat.model.extension.cef" description="VirSat DLR CEF Concept" version="1.6" displayName="CEF">
+  <categories name="SystemMode" applicableFor="de.dlr.sc.virsat.model.extension.cef.System">
+    <properties xsi:type="dvlm_cppd:StringProperty" name="note" description="A note for the mode" defaultValue="no description"/>
+  </categories>
+  <categories name="Parameter" applicableFor="de.dlr.sc.virsat.model.extension.cef.System de.dlr.sc.virsat.model.extension.cef.SubSystem de.dlr.sc.virsat.model.extension.cef.Equipment">
+    <properties xsi:type="dvlm_cppd:FloatProperty" name="defaultValue" defaultValue="0"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="modeValues" description="An Array of Values, for default and other modes" type="de.dlr.sc.virsat.model.extension.cef.Value">
+      <arrayModifier xsi:type="dvlm_cppd:DynamicArrayModifier"/>
+    </properties>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="rangeValues" description="Add minimum and/or Maximum value for the parameter" type="de.dlr.sc.virsat.model.extension.cef.ParameterRange">
+      <arrayModifier xsi:type="dvlm_cppd:DynamicArrayModifier"/>
+    </properties>
+    <properties xsi:type="dvlm_cppd:StringProperty" name="note" description="A note for the Parameter"/>
+  </categories>
+  <categories name="Value">
+    <properties xsi:type="dvlm_cppd:FloatProperty" name="value" defaultValue="0"/>
+    <properties xsi:type="dvlm_cppd:ReferenceProperty" name="mode" description="The Mode for which this Value is Valid. Leave unassigned if default Mode" referenceType="de.dlr.sc.virsat.model.extension.cef.SystemMode"/>
+  </categories>
+  <categories name="SystemParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.System" cardinality="1">
+    <properties xsi:type="dvlm_cppd:FloatProperty" name="systemMargin" description="Constant system margin" quantityKindName="Dimensionless" unitName="Percent" defaultValue="0"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="modeDuration" description="Duration of the modes" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Time" unitName="Second"/>
+  </categories>
+  <categories name="SystemMassParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.System" cardinality="1">
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massTotal"/>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massTotal"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massTotalWithMargin"/>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massTotalWithMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massTotalWithMargin"/>
+        <right xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:AdditionAndSubtraction">
+            <left xsi:type="dvlm_calc:NumberLiteral" value="1"/>
+            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemParameters.systemMargin"/>
+          </right>
+        </right>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massTotalWithMarginWithSystemMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
+        <left xsi:type="dvlm_calc:AdditionAndSubtraction">
+          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massTotalWithMarginWithSystemMargin"/>
+          <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massPropellant"/>
+        </left>
+        <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massAdapter"/>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massLaunch"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:AdditionAndSubtraction" operator="-">
+        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massLaunchMax"/>
+        <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massLaunch"/>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemMassParameters.massBuffer"/>
+    </equationDefinitions>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massLaunch" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massTotal" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massTotalWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massTotalWithMarginWithSystemMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massAdapter" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massPropellant" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massLaunchMax" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massBuffer" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+  </categories>
+  <categories name="SystemPowerParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.System" cardinality="1">
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.SubSystemPowerParameters.powerAvgWithMargin"/>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemPowerParameters.powerAvgWithMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemPowerParameters.powerAvgWithMargin"/>
+        <right xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:AdditionAndSubtraction">
+            <left xsi:type="dvlm_calc:NumberLiteral" value="1"/>
+            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemParameters.systemMargin"/>
+          </right>
+        </right>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemPowerParameters.powerAvgWithSystemMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.SubSystemPowerParameters.powerEnergyWithMargin"/>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemPowerParameters.powerEnergyWithMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemPowerParameters.powerEnergyWithMargin"/>
+        <right xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:AdditionAndSubtraction">
+            <left xsi:type="dvlm_calc:NumberLiteral" value="1"/>
+            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemParameters.systemMargin"/>
+          </right>
+        </right>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SystemPowerParameters.powerEnergyWithSystemMargin"/>
+    </equationDefinitions>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="powerAvgWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="powerAvgWithSystemMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="powerEnergyWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Energy and Work" unitName="Joule"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="powerEnergyWithSystemMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Energy and Work" unitName="Joule"/>
+  </categories>
+  <categories name="SubSystemMassParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.SubSystem" cardinality="1">
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotal" depth="1"/>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massTotal"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massTotalWithMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:AdditionAndSubtraction" operator="-">
+        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massTotalWithMargin"/>
+        <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massTotal"/>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:AdditionAndSubtraction" operator="-">
+        <left xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="/">
+            <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massTotalWithMargin"/>
+            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massTotal"/>
+          </right>
+        </left>
+        <right xsi:type="dvlm_calc:NumberLiteral" value="1"/>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters.massMarginPercentage"/>
+    </equationDefinitions>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massTotal" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massTotalWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massMarginPercentage" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Dimensionless" unitName="Percent"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+  </categories>
+  <categories name="SubSystemPowerParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.SubSystem" cardinality="1">
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerAvgWithMargin" depth="1"/>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemPowerParameters.powerAvgWithMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemPowerParameters.powerAvgWithMargin"/>
+        <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.SystemParameters.modeDuration"/>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.SubSystemPowerParameters.powerEnergyWithMargin"/>
+    </equationDefinitions>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="powerAvgWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="powerEnergyWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Energy and Work" unitName="Joule"/>
+  </categories>
+  <categories name="EquipmentParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.Equipment" cardinality="1">
+    <properties xsi:type="dvlm_cppd:FloatProperty" name="marginMaturity" description="Constant Equipment Margin" quantityKindName="Dimensionless" unitName="Percent" defaultValue="0"/>
+    <properties xsi:type="dvlm_cppd:IntProperty" name="unitQuantity" description="Number of Equipments" quantityKindName="Dimensionless" unitName="No Unit" defaultValue="1"/>
+  </categories>
+  <categories name="EquipmentMassParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.Equipment" cardinality="1">
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+        <left xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:AdditionAndSubtraction">
+            <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
+            <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotal" depth="1"/>
+          </right>
+        </left>
+        <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.unitQuantity"/>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotal"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
+        <left xsi:type="dvlm_calc:AdditionAndSubtraction">
+          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
+          <right xsi:type="dvlm_calc:Parenthesis">
+            <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+              <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
+              <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
+            </right>
+          </right>
+        </left>
+        <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin"/>
+    </equationDefinitions>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massPerUnit" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massTotal" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="massTotalWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Mass" unitName="Kilogram"/>
+  </categories>
+  <categories name="EquipmentPowerParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.Equipment" cardinality="1">
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
+        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitOn"/>
+        <right xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+            <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitOn"/>
+            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
+          </right>
+        </right>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitOnWithMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
+        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitStby"/>
+        <right xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+            <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitStby"/>
+            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
+          </right>
+        </right>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitStbyWithMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
+        <left xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitOnWithMargin"/>
+          <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.powerDutyCycle"/>
+        </left>
+        <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitStbyWithMargin"/>
+          <right xsi:type="dvlm_calc:Parenthesis">
+            <right xsi:type="dvlm_calc:AdditionAndSubtraction" operator="-">
+              <left xsi:type="dvlm_calc:NumberLiteral" value="1"/>
+              <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.powerDutyCycle"/>
+            </right>
+          </right>
+        </right>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitAvgWithMargin"/>
+    </equationDefinitions>
+    <equationDefinitions>
+      <expression xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+        <left xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:AdditionAndSubtraction">
+            <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerPerUnitAvgWithMargin"/>
+            <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerAvgWithMargin" depth="1"/>
+          </right>
+        </left>
+        <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.activeUnits"/>
+      </expression>
+      <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters.PowerAvgWithMargin"/>
+    </equationDefinitions>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="activeUnits" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Dimensionless" unitName="No Unit"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="powerDutyCycle" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Dimensionless" unitName="Percent"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="PowerPerUnitOn" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="PowerPerUnitStby" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="PowerPerUnitOnWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="PowerPerUnitStbyWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="PowerPerUnitAvgWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="PowerAvgWithMargin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Power" unitName="Watt"/>
+  </categories>
+  <categories name="EquipmentTemperatureParameters" applicableFor="de.dlr.sc.virsat.model.extension.cef.Equipment" cardinality="1">
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="temperatureNoOpsMax" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Temperature" unitName="Degree Celsius"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="temperatureNoOpsMin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Temperature" unitName="Degree Celsius"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="temperatureOpsMax" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Temperature" unitName="Degree Celsius"/>
+    <properties xsi:type="dvlm_cppd:ComposedProperty" name="temperatureOpsMin" type="de.dlr.sc.virsat.model.extension.cef.Parameter" quantityKindName="Temperature" unitName="Degree Celsius"/>
+  </categories>
+  <categories name="ParameterRange" cardinality="1">
+    <properties xsi:type="dvlm_cppd:FloatProperty" name="minValue"/>
+    <properties xsi:type="dvlm_cppd:FloatProperty" name="maxValue"/>
+  </categories>
+  <categories name="Document" description="Category to describe documents such as specifications" applicableFor="de.dlr.sc.virsat.model.extension.cef.SystemOfSystems de.dlr.sc.virsat.model.extension.cef.System de.dlr.sc.virsat.model.extension.cef.SubSystem de.dlr.sc.virsat.model.extension.cef.Equipment">
+    <properties xsi:type="dvlm_cppd:StringProperty" name="name" description="Name of the document"/>
+    <properties xsi:type="dvlm_cppd:StringProperty" name="note" description="Some not of the document"/>
+    <properties xsi:type="dvlm_cppd:StringProperty" name="url" description="A reference URL to the document"/>
+    <properties xsi:type="dvlm_cppd:ResourceProperty" name="file" description="The actual file of the document"/>
+  </categories>
+  <categories name="ExcelCalculation" applicableFor="de.dlr.sc.virsat.model.extension.cef.System de.dlr.sc.virsat.model.extension.cef.SubSystem de.dlr.sc.virsat.model.extension.cef.Equipment">
+    <properties xsi:type="dvlm_cppd:ResourceProperty" name="excelFile"/>
+    <properties xsi:type="dvlm_cppd:ReferenceProperty" name="fromVirSat2Excel" referenceType="de.dlr.sc.virsat.model.extension.cef.Parameter">
+      <arrayModifier xsi:type="dvlm_cppd:DynamicArrayModifier"/>
+    </properties>
+    <properties xsi:type="dvlm_cppd:ReferenceProperty" name="fromExcel2VirSat" referenceType="de.dlr.sc.virsat.model.extension.cef.Parameter">
+      <arrayModifier xsi:type="dvlm_cppd:DynamicArrayModifier"/>
+    </properties>
+  </categories>
+  <structuralElements name="SystemOfSystems" shortName="SysOfSys" applicableFor="de.dlr.sc.virsat.model.extension.cef.SystemOfSystems" isRootStructuralElement="true"/>
+  <structuralElements name="System" shortName="Sys" applicableFor="de.dlr.sc.virsat.model.extension.cef.SystemOfSystems" isRootStructuralElement="true"/>
+  <structuralElements name="SubSystem" shortName="SubSys" applicableFor="de.dlr.sc.virsat.model.extension.cef.System"/>
+  <structuralElements name="Equipment" shortName="Eqp" applicableFor="de.dlr.sc.virsat.model.extension.cef.Equipment de.dlr.sc.virsat.model.extension.cef.SubSystem"/>
+</dvlm_c:Concept>

--- a/de.dlr.sc.virsat.model.extension.cef/concept/concept_v1_6.xmi
+++ b/de.dlr.sc.virsat.model.extension.cef/concept/concept_v1_6.xmi
@@ -172,17 +172,22 @@
       <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotal"/>
     </equationDefinitions>
     <equationDefinitions>
-      <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
-        <left xsi:type="dvlm_calc:AdditionAndSubtraction">
-          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
-          <right xsi:type="dvlm_calc:Parenthesis">
-            <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+      <expression xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+        <left xsi:type="dvlm_calc:Parenthesis">
+          <right xsi:type="dvlm_calc:AdditionAndSubtraction">
+            <left xsi:type="dvlm_calc:AdditionAndSubtraction">
               <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
-              <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
-            </right>
+              <right xsi:type="dvlm_calc:Parenthesis">
+                <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+                  <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massPerUnit"/>
+                  <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.marginMaturity"/>
+                </right>
+              </right>
+            </left>
+            <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
           </right>
         </left>
-        <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
+        <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentParameters.unitQuantity"/>
       </expression>
       <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters.massTotalWithMargin"/>
     </equationDefinitions>

--- a/de.dlr.sc.virsat.model.extension.cef/plugin.xml
+++ b/de.dlr.sc.virsat.model.extension.cef/plugin.xml
@@ -4,7 +4,7 @@
 	<extension point="de.dlr.sc.virsat.model.Concept">
 	<concept
 	          id="de.dlr.sc.virsat.model.extension.cef"
-	          version="1.5"
+	          version="1.6"
 	          xmi="concept/concept.xmi">
 	    </concept>
 	</extension>
@@ -143,6 +143,14 @@
 		version="1.5"
 		class="de.dlr.sc.virsat.model.extension.cef.migrator.Migrator1v5"
 		xmi="concept/concept_v1_5.xmi">
+	</migrator>
+</extension>
+<extension point="de.dlr.sc.virsat.model.edit.ConceptMigrator">
+	<migrator
+		id="de.dlr.sc.virsat.model.extension.cef"
+		version="1.6"
+		class="de.dlr.sc.virsat.model.extension.cef.migrator.Migrator1v6"
+		xmi="concept/concept_v1_6.xmi">
 	</migrator>
 </extension>
 	<!-- Plugin.XML Protected Region End -->

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/PluginXml.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/PluginXml.java
@@ -54,11 +54,17 @@ public class PluginXml {
 			public static final String VERSION = "1.5";
 			public static final String XMI = "concept/concept_v1_5.xmi";
 		}	
+		public static class Migrator1_6 {
+			public static final String CLASSNAME = "de.dlr.sc.virsat.model.extension.cef.migrator.Migrator1v6";
+			public static final String ID = "de.dlr.sc.virsat.model.extension.cef";
+			public static final String VERSION = "1.6";
+			public static final String XMI = "concept/concept_v1_6.xmi";
+		}	
 	}
 	public static class concept {
 		public static class Concept {
 			public static final String ID = "de.dlr.sc.virsat.model.extension.cef";
-			public static final String VERSION = "1.5";
+			public static final String VERSION = "1.6";
 			public static final String XMI = "concept/concept.xmi";
 		}	
 	}

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/migrator/AMigrator1v6.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/migrator/AMigrator1v6.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2019 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.extension.cef.migrator;
+
+import de.dlr.sc.virsat.model.concept.migrator.AMigrator;
+
+
+// *****************************************************************
+// * Class Declaration
+// *****************************************************************
+
+/**
+ * Auto Generated Abstract Generator Gap Class
+ * 
+ * Don't Manually modify this class
+ * 
+ * VirSat DLR CEF Concept
+ * 
+ */	
+public abstract class AMigrator1v6 extends AMigrator {
+
+}

--- a/de.dlr.sc.virsat.model.extension.cef/src/de/dlr/sc/virsat/model/extension/cef/migrator/Migrator1v6.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src/de/dlr/sc/virsat/model/extension/cef/migrator/Migrator1v6.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2019 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.extension.cef.migrator;
+
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.concept.migrator.IMigrator;
+
+
+// *****************************************************************
+// * Class Declaration
+// *****************************************************************
+
+/**
+ * Auto Generated Class inheriting from Generator Gap Class
+ * 
+ * This class is generated once, do your changes here
+ * 
+ * VirSat DLR CEF Concept
+ * 
+ */
+public class Migrator1v6 extends AMigrator1v6 implements IMigrator {
+
+	@Override
+	public void migrate(Concept concept, IMigrator previousMigrator) {
+		super.migrate(concept, previousMigrator);
+	}
+}

--- a/de.dlr.sc.virsat.model.extension.cefx/concept/concept.concept
+++ b/de.dlr.sc.virsat.model.extension.cefx/concept/concept.concept
@@ -128,7 +128,7 @@ Concept de.dlr.sc.virsat.model.extension.cefx
 		Type massTotalWithMargin of Category Parameter quantityKind "Mass" unit "Kilogram";
 		
 		Ref: massTotal = massPerUnit + summary{massTotal, 1};
-		Ref: massTotalWithMargin = massTotal + (massTotal * EquipmentParameters.marginMaturity); 
+		Ref: massTotalWithMargin = massPerUnit + (massPerUnit * EquipmentParameters.marginMaturity) + summary{massTotalWithMargin, 1}; 
 	}
 	
 	Category EquipmentPowerParameters {

--- a/de.dlr.sc.virsat.model.extension.cefx/concept/concept.xmi
+++ b/de.dlr.sc.virsat.model.extension.cefx/concept/concept.xmi
@@ -197,13 +197,16 @@
     </equationDefinitions>
     <equationDefinitions>
       <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
-        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massTotal"/>
-        <right xsi:type="dvlm_calc:Parenthesis">
-          <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
-            <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massTotal"/>
-            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentParameters.marginMaturity"/>
+        <left xsi:type="dvlm_calc:AdditionAndSubtraction">
+          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massPerUnit"/>
+          <right xsi:type="dvlm_calc:Parenthesis">
+            <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+              <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massPerUnit"/>
+              <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentParameters.marginMaturity"/>
+            </right>
           </right>
-        </right>
+        </left>
+        <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
       </expression>
       <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massTotalWithMargin"/>
     </equationDefinitions>

--- a/de.dlr.sc.virsat.model.extension.cefx/concept/concept_v1_0.xmi
+++ b/de.dlr.sc.virsat.model.extension.cefx/concept/concept_v1_0.xmi
@@ -197,13 +197,16 @@
     </equationDefinitions>
     <equationDefinitions>
       <expression xsi:type="dvlm_calc:AdditionAndSubtraction">
-        <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massTotal"/>
-        <right xsi:type="dvlm_calc:Parenthesis">
-          <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
-            <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massTotal"/>
-            <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentParameters.marginMaturity"/>
+        <left xsi:type="dvlm_calc:AdditionAndSubtraction">
+          <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massPerUnit"/>
+          <right xsi:type="dvlm_calc:Parenthesis">
+            <right xsi:type="dvlm_calc:MultiplicationAndDivision" operator="*">
+              <left xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massPerUnit"/>
+              <right xsi:type="dvlm_calc:ReferencedDefinitionInput" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentParameters.marginMaturity"/>
+            </right>
           </right>
-        </right>
+        </left>
+        <right xsi:type="dvlm_calc:SetFunction" operator="summary" typeDefinition="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massTotalWithMargin" depth="1"/>
       </expression>
       <result xsi:type="dvlm_calc:TypeDefinitionResult" reference="de.dlr.sc.virsat.model.extension.cefx.EquipmentMassParameters.massTotalWithMargin"/>
     </equationDefinitions>


### PR DESCRIPTION
Fix computation of mass with margin to also consider the margin of all child-equipments. 

Manual changes of this branch are only in the concepts (CEF + CEFX). The equaption of the EqipmentMassParameters has been edited.

Closes #10 