### PR TITLE
Feature/task 91 npe when adding only s

### DIFF
--- a/de.dlr.sc.virsat.model.extension.cefx.ui/src/de/dlr/sc/virsat/model/extension/cefx/ui/masssummary/UiSnippetSystem.java
+++ b/de.dlr.sc.virsat.model.extension.cefx.ui/src/de/dlr/sc/virsat/model/extension/cefx/ui/masssummary/UiSnippetSystem.java
@@ -106,7 +106,7 @@ public class UiSnippetSystem extends AUiSnippetTable {
 						if (element.equals(ROWS[DRY_MASS_ROW])) {
 							return printParameter(systemMassParams != null ? systemMassParams.getMassTotalWithMargin() : null, KILOGRAM);
 						} else if (element.equals(ROWS[SYSTEM_MARGIN_ROW])) {
-							if (systemParams != null && systemParams.isSetSystemMargin() && systemMassParams.getMassTotalWithMargin().isSetDefaultValue()) {
+							if (systemParams != null && systemParams.isSetSystemMargin() && systemMassParams != null && systemMassParams.getMassTotalWithMargin().isSetDefaultValue()) {
 								return printParameterWithMargin(systemMassParams.getMassTotalWithMargin(), systemParams.getSystemMarginBean(), KILOGRAM);
 							} else {
 								return UNDEFINED;


### PR DESCRIPTION
Added missing check to see if the system mass parameters exist in the model.

Closes #91 
