### PR TITLE
Change tmodel reference to windwos tmodel reference

### DIFF
--- a/de.dlr.sc.virsat.cef.target/targetForReferences.target
+++ b/de.dlr.sc.virsat.cef.target/targetForReferences.target
@@ -2,20 +2,19 @@
 		<?pde version="3.8"?><target name="targetForReferences" sequenceNumber="1">
 		<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="de.dlr.sc.virsat.target.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.apps.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.branding.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.build.feature.feature.group" version="0.0.0"/>
-		<unit id="de.dlr.sc.virsat.commons.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.excel.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.commons.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.dependencies.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.docs.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.external.lib.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.graphiti.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.javadoc.api.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.license.feature.feature.group" version="0.0.0"/>
-		<unit id="de.dlr.sc.virsat.model.ext.core.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.model.calculation.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.ext.core.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.model.extension.budget.mass.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.model.extension.budget.power.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.model.extension.funcelectrical.feature.feature.group" version="0.0.0"/>
@@ -32,7 +31,7 @@
 		<unit id="de.dlr.sc.virsat.team.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.test.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.uiengine.feature.feature.group" version="0.0.0"/>
-		<repository location="https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/development/"/>
+		<repository location="https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/integration/4.9.0/"/>
 		</location>
 		</locations>
 		<environment>

--- a/de.dlr.sc.virsat.cef.target/targetForReferences.target
+++ b/de.dlr.sc.virsat.cef.target/targetForReferences.target
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+		<?pde version="3.8"?><target name="targetForReferences" sequenceNumber="1">
+		<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="de.dlr.sc.virsat.target.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.apps.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.branding.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.build.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.commons.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.excel.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.dependencies.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.docs.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.external.lib.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.graphiti.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.javadoc.api.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.license.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.ext.core.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.calculation.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.budget.mass.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.budget.power.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.funcelectrical.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.statemachines.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.requirements.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.maturity.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.ps.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.tests.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.visualisation.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.extension.mechanical.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.model.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.project.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.server.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.team.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.test.feature.feature.group" version="0.0.0"/>
+		<unit id="de.dlr.sc.virsat.uiengine.feature.feature.group" version="0.0.0"/>
+		<repository location="https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/development/"/>
+		</location>
+		</locations>
+		<environment>
+		<os></os>
+		<ws></ws>
+		<arch></arch>
+		<nl></nl> 
+		</environment>
+		<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/"/>
+		</target>

--- a/de.dlr.sc.virsat.cef.target/tmodel-src/virsat_cef_development.tmodel
+++ b/de.dlr.sc.virsat.cef.target/tmodel-src/virsat_cef_development.tmodel
@@ -2,6 +2,6 @@ Target virsat_cef_development extends virsat_windows {
 	Import core_development 
 	
 	ReferencedTarget RepositoryLocation VirSat4CoreDevelopment url "https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/development/"{	
-		Unit de.dlr.sc.virsat.target.feature.feature.group version newest; 
+		Unit de.dlr.sc.virsat.target.feature.feature.group version newest;
 	}
 } 

--- a/de.dlr.sc.virsat.cef.target/tmodel-src/virsat_cef_development.tmodel
+++ b/de.dlr.sc.virsat.cef.target/tmodel-src/virsat_cef_development.tmodel
@@ -1,7 +1,7 @@
-Target virsat_cef_development extends virsat {
+Target virsat_cef_development extends virsat_windows {
 	Import core_development 
 	
-	RepositoryLocation VirSat4CoreDevelopment url "https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/development/"{	
+	ReferencedTarget RepositoryLocation VirSat4CoreDevelopment url "https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/development/"{	
 		Unit de.dlr.sc.virsat.target.feature.feature.group version newest; 
 	}
 } 

--- a/de.dlr.sc.virsat.cef.target/tmodel-src/virsat_cef_integration.tmodel
+++ b/de.dlr.sc.virsat.cef.target/tmodel-src/virsat_cef_integration.tmodel
@@ -1,8 +1,9 @@
-Target virsat_cef_integration extends virsat {
+Target virsat_cef_integration extends virsat_windows {
 	Import core_integration
 	
 	RepositoryLocation VirSat4CoreIntegration url "https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/integration/4.12.0/"{	
 		Unit de.dlr.sc.virsat.target.feature.feature.group version newest;
 	} 
+	
 }
  

--- a/de.dlr.sc.virsat.cef.target/tmodel-src/virsat_cef_release.tmodel
+++ b/de.dlr.sc.virsat.cef.target/tmodel-src/virsat_cef_release.tmodel
@@ -1,4 +1,4 @@
-Target virsat_cef_release extends virsat {
+Target virsat_cef_release extends virsat_windows {
 	RepositoryLocation VirSat4CoreRelease url "https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/release/4.12.0/4763/" {	
 		Unit de.dlr.sc.virsat.apps.feature.feature.group version 4.12.0.r202007311110;
 		Unit de.dlr.sc.virsat.branding.feature.feature.group version 4.12.0.r202007311110;

--- a/de.dlr.sc.virsat.cef.target/virsat_cef_integration.target
+++ b/de.dlr.sc.virsat.cef.target/virsat_cef_integration.target
@@ -34,6 +34,51 @@
 		<unit id="de.dlr.sc.virsat.uiengine.feature.feature.group" version="0.0.0"/>
 		<repository location="https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/integration/4.12.0/"/>
 		</location>              
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.nebula.widgets.gallery.feature.feature.group" version="1.0.0.201907151344"/>
+		<unit id="org.eclipse.nebula.widgets.tablecombo.feature.feature.group" version="1.2.0.201907151344"/>
+		<repository location="https://download.eclipse.org/nebula/releases/2.2.0/"/>
+		</location>              
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
+		<unit id="org.apache.commons.io" version="2.6.0.v20190123-2029"/>
+		<unit id="org.apache.commons.io.source" version="2.6.0.v20190123-2029"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository/"/>
+		</location>              
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.3.11.202005260905"/>
+		<unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="1.4.1.202002140949"/>
+		<unit id="org.eclipse.emf.sdk.feature.group" version="2.22.0.v20200519-1135"/>
+		<unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.12.0.201805140824"/>
+		<unit id="org.eclipse.equinox.executable.feature.group" version="3.8.800.v20200514-1529"/>
+		<unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.17.0.202005151449"/>
+		<unit id="org.eclipse.jdt.source.feature.group" version="3.18.400.v20200604-0540"/>
+		<unit id="org.eclipse.ocl.all.sdk.feature.group" version="5.12.0.v20200608-1555"/>
+		<unit id="org.eclipse.pde.source.feature.group" version="3.14.400.v20200604-0540"/>
+		<unit id="org.eclipse.platform.sdk" version="4.16.0.I20200604-0540"/>
+		<unit id="org.eclipse.swtbot.eclipse.feature.group" version="3.0.0.202006031738"/>
+		<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="3.0.0.202006031738"/>
+		<unit id="org.eclipse.swtbot.feature.group" version="3.0.0.202006031738"/>
+		<unit id="org.eclipse.swtbot.forms.feature.group" version="3.0.0.202006031738"/>
+		<unit id="org.eclipse.swtbot.generator.feature.feature.group" version="3.0.0.202006031738"/>
+		<unit id="org.eclipse.swtbot.ide.feature.group" version="3.0.0.202006031738"/>
+		<unit id="org.eclipse.xtext.sdk.feature.group" version="2.22.0.v20200602-1533"/>
+		<unit id="org.eclipse.gef.feature.group" version="3.11.0.201606061308"/>
+		<unit id="org.eclipse.egit.feature.group" version="5.8.0.202006091008-r"/>
+		<repository location="http://download.eclipse.org/releases/2020-06"/>
+		</location>              
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.team.svn.feature.group" version="4.0.5.I20170425-1700"/>
+		<repository location="https://download.eclipse.org/technology/subversive/4.0/update-site/"/>
+		</location>              
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.polarion.eclipse.team.svn.connector.feature.group" version="6.0.4.I20161211-1700"/>
+		<unit id="org.polarion.eclipse.team.svn.connector.source.feature.group" version="6.0.4.I20161211-1700"/>
+		<unit id="org.polarion.eclipse.team.svn.connector.sources.feature.group" version="6.0.4.I20161211-1700"/>
+		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.feature.group" version="6.0.4.I20161211-1700"/>
+		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.sources.feature.group" version="6.0.4.I20161211-1700"/>
+		<repository location="http://community.polarion.com/projects/subversive/download/eclipse/6.0/update-site/"/>
+		</location>              
 		</locations>
 		<environment>
 		<os>win32</os>

--- a/de.dlr.sc.virsat.cef.target/virsat_cef_integration.target
+++ b/de.dlr.sc.virsat.cef.target/virsat_cef_integration.target
@@ -34,51 +34,6 @@
 		<unit id="de.dlr.sc.virsat.uiengine.feature.feature.group" version="0.0.0"/>
 		<repository location="https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/integration/4.12.0/"/>
 		</location>              
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.nebula.widgets.gallery.feature.feature.group" version="1.0.0.201907151344"/>
-		<unit id="org.eclipse.nebula.widgets.tablecombo.feature.feature.group" version="1.2.0.201907151344"/>
-		<repository location="https://download.eclipse.org/nebula/releases/2.2.0/"/>
-		</location>              
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
-		<unit id="org.apache.commons.io" version="2.6.0.v20190123-2029"/>
-		<unit id="org.apache.commons.io.source" version="2.6.0.v20190123-2029"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository/"/>
-		</location>              
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.3.11.202005260905"/>
-		<unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="1.4.1.202002140949"/>
-		<unit id="org.eclipse.emf.sdk.feature.group" version="2.22.0.v20200519-1135"/>
-		<unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.12.0.201805140824"/>
-		<unit id="org.eclipse.equinox.executable.feature.group" version="3.8.800.v20200514-1529"/>
-		<unit id="org.eclipse.graphiti.sdk.feature.feature.group" version="0.17.0.202005151449"/>
-		<unit id="org.eclipse.jdt.source.feature.group" version="3.18.400.v20200604-0540"/>
-		<unit id="org.eclipse.ocl.all.sdk.feature.group" version="5.12.0.v20200608-1555"/>
-		<unit id="org.eclipse.pde.source.feature.group" version="3.14.400.v20200604-0540"/>
-		<unit id="org.eclipse.platform.sdk" version="4.16.0.I20200604-0540"/>
-		<unit id="org.eclipse.swtbot.eclipse.feature.group" version="3.0.0.202006031738"/>
-		<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="3.0.0.202006031738"/>
-		<unit id="org.eclipse.swtbot.feature.group" version="3.0.0.202006031738"/>
-		<unit id="org.eclipse.swtbot.forms.feature.group" version="3.0.0.202006031738"/>
-		<unit id="org.eclipse.swtbot.generator.feature.feature.group" version="3.0.0.202006031738"/>
-		<unit id="org.eclipse.swtbot.ide.feature.group" version="3.0.0.202006031738"/>
-		<unit id="org.eclipse.xtext.sdk.feature.group" version="2.22.0.v20200602-1533"/>
-		<unit id="org.eclipse.gef.feature.group" version="3.11.0.201606061308"/>
-		<unit id="org.eclipse.egit.feature.group" version="5.8.0.202006091008-r"/>
-		<repository location="http://download.eclipse.org/releases/2020-06"/>
-		</location>              
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.team.svn.feature.group" version="4.0.5.I20170425-1700"/>
-		<repository location="https://download.eclipse.org/technology/subversive/4.0/update-site/"/>
-		</location>              
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.polarion.eclipse.team.svn.connector.feature.group" version="6.0.4.I20161211-1700"/>
-		<unit id="org.polarion.eclipse.team.svn.connector.source.feature.group" version="6.0.4.I20161211-1700"/>
-		<unit id="org.polarion.eclipse.team.svn.connector.sources.feature.group" version="6.0.4.I20161211-1700"/>
-		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.feature.group" version="6.0.4.I20161211-1700"/>
-		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.sources.feature.group" version="6.0.4.I20161211-1700"/>
-		<repository location="http://community.polarion.com/projects/subversive/download/eclipse/6.0/update-site/"/>
-		</location>              
 		</locations>
 		<environment>
 		<os>win32</os>


### PR DESCRIPTION
Update tmodels to use the virsat /linux tmodels from core...

As CEF is mainly targeting windows (Windows computers in CEF) I simply changed the reference. We could also add windows and linux tmodels in CEF... If we need it 