### PR TITLE
Adjust CEF to Bean API

### DIFF
--- a/de.dlr.sc.virsat.cef.target/virsat_cef_development.target
+++ b/de.dlr.sc.virsat.cef.target/virsat_cef_development.target
@@ -33,18 +33,18 @@
 		<unit id="de.dlr.sc.virsat.test.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.uiengine.feature.feature.group" version="0.0.0"/>
 		<repository location="https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/development/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.nebula.widgets.gallery.feature.feature.group" version="1.0.0.201907151344"/>
 		<unit id="org.eclipse.nebula.widgets.tablecombo.feature.feature.group" version="1.2.0.201907151344"/>
 		<repository location="https://download.eclipse.org/nebula/releases/2.2.0/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 		<unit id="org.apache.commons.io" version="2.6.0.v20190123-2029"/>
 		<unit id="org.apache.commons.io.source" version="2.6.0.v20190123-2029"/>
 		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.3.11.202005260905"/>
 		<unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="1.4.1.202002140949"/>
@@ -66,11 +66,11 @@
 		<unit id="org.eclipse.gef.feature.group" version="3.11.0.201606061308"/>
 		<unit id="org.eclipse.egit.feature.group" version="5.8.0.202006091008-r"/>
 		<repository location="http://download.eclipse.org/releases/2020-06"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.team.svn.feature.group" version="4.0.5.I20170425-1700"/>
 		<repository location="https://download.eclipse.org/technology/subversive/4.0/update-site/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.polarion.eclipse.team.svn.connector.feature.group" version="6.0.4.I20161211-1700"/>
 		<unit id="org.polarion.eclipse.team.svn.connector.source.feature.group" version="6.0.4.I20161211-1700"/>
@@ -78,7 +78,7 @@
 		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.feature.group" version="6.0.4.I20161211-1700"/>
 		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.sources.feature.group" version="6.0.4.I20161211-1700"/>
 		<repository location="http://community.polarion.com/projects/subversive/download/eclipse/6.0/update-site/"/>
-		</location>              
+		</location>
 		</locations>
 		<environment>
 		<os>win32</os>

--- a/de.dlr.sc.virsat.cef.target/virsat_cef_integration.target
+++ b/de.dlr.sc.virsat.cef.target/virsat_cef_integration.target
@@ -33,18 +33,18 @@
 		<unit id="de.dlr.sc.virsat.test.feature.feature.group" version="0.0.0"/>
 		<unit id="de.dlr.sc.virsat.uiengine.feature.feature.group" version="0.0.0"/>
 		<repository location="https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/integration/4.12.0/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.nebula.widgets.gallery.feature.feature.group" version="1.0.0.201907151344"/>
 		<unit id="org.eclipse.nebula.widgets.tablecombo.feature.feature.group" version="1.2.0.201907151344"/>
 		<repository location="https://download.eclipse.org/nebula/releases/2.2.0/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 		<unit id="org.apache.commons.io" version="2.6.0.v20190123-2029"/>
 		<unit id="org.apache.commons.io.source" version="2.6.0.v20190123-2029"/>
 		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.3.11.202005260905"/>
 		<unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="1.4.1.202002140949"/>
@@ -66,11 +66,11 @@
 		<unit id="org.eclipse.gef.feature.group" version="3.11.0.201606061308"/>
 		<unit id="org.eclipse.egit.feature.group" version="5.8.0.202006091008-r"/>
 		<repository location="http://download.eclipse.org/releases/2020-06"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.team.svn.feature.group" version="4.0.5.I20170425-1700"/>
 		<repository location="https://download.eclipse.org/technology/subversive/4.0/update-site/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.polarion.eclipse.team.svn.connector.feature.group" version="6.0.4.I20161211-1700"/>
 		<unit id="org.polarion.eclipse.team.svn.connector.source.feature.group" version="6.0.4.I20161211-1700"/>
@@ -78,7 +78,7 @@
 		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.feature.group" version="6.0.4.I20161211-1700"/>
 		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.sources.feature.group" version="6.0.4.I20161211-1700"/>
 		<repository location="http://community.polarion.com/projects/subversive/download/eclipse/6.0/update-site/"/>
-		</location>              
+		</location>
 		</locations>
 		<environment>
 		<os>win32</os>

--- a/de.dlr.sc.virsat.cef.target/virsat_cef_release.target
+++ b/de.dlr.sc.virsat.cef.target/virsat_cef_release.target
@@ -27,18 +27,18 @@
 		<unit id="de.dlr.sc.virsat.uiengine.feature.feature.group" version="4.12.0.r202007311110"/>
 		<unit id="de.dlr.sc.virsat.target.feature.feature.group" version="4.12.0.r202007311110"/>
 		<repository location="https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-Core/release/4.12.0/4763/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.nebula.widgets.gallery.feature.feature.group" version="1.0.0.201907151344"/>
 		<unit id="org.eclipse.nebula.widgets.tablecombo.feature.feature.group" version="1.2.0.201907151344"/>
 		<repository location="https://download.eclipse.org/nebula/releases/2.2.0/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 		<unit id="org.apache.commons.io" version="2.6.0.v20190123-2029"/>
 		<unit id="org.apache.commons.io.source" version="2.6.0.v20190123-2029"/>
 		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.3.11.202005260905"/>
 		<unit id="org.eclipse.emf.edapt.runtime.feature.feature.group" version="1.4.1.202002140949"/>
@@ -60,11 +60,11 @@
 		<unit id="org.eclipse.gef.feature.group" version="3.11.0.201606061308"/>
 		<unit id="org.eclipse.egit.feature.group" version="5.8.0.202006091008-r"/>
 		<repository location="http://download.eclipse.org/releases/2020-06"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.team.svn.feature.group" version="4.0.5.I20170425-1700"/>
 		<repository location="https://download.eclipse.org/technology/subversive/4.0/update-site/"/>
-		</location>              
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.polarion.eclipse.team.svn.connector.feature.group" version="6.0.4.I20161211-1700"/>
 		<unit id="org.polarion.eclipse.team.svn.connector.source.feature.group" version="6.0.4.I20161211-1700"/>
@@ -72,7 +72,7 @@
 		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.feature.group" version="6.0.4.I20161211-1700"/>
 		<unit id="org.polarion.eclipse.team.svn.connector.svnkit18.sources.feature.group" version="6.0.4.I20161211-1700"/>
 		<repository location="http://community.polarion.com/projects/subversive/download/eclipse/6.0/update-site/"/>
-		</location>              
+		</location>
 		</locations>
 		<environment>
 		<os>win32</os>

--- a/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/AAInterface.java
+++ b/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/AAInterface.java
@@ -12,17 +12,21 @@ package de.dlr.sc.virsat.model.extension.cef.interfaces.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import org.eclipse.emf.common.command.Command;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.common.command.Command;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -37,6 +41,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AAInterface extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.interfaces.AInterface";
@@ -98,6 +104,7 @@ public abstract class AAInterface extends GenericCategory implements IBeanCatego
 		return note.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyString getNoteBean() {
 		safeAccessNote();
 		return note;

--- a/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/AAInterfaceEnd.java
+++ b/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/AAInterfaceEnd.java
@@ -12,12 +12,15 @@ package de.dlr.sc.virsat.model.extension.cef.interfaces.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
+import javax.xml.bind.annotation.XmlAccessType;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.common.command.Command;
@@ -25,6 +28,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropert
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyInt;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -39,6 +43,8 @@ import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyInt;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AAInterfaceEnd extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.interfaces.AInterfaceEnd";
@@ -106,6 +112,7 @@ public abstract class AAInterfaceEnd extends GenericCategory implements IBeanCat
 		return quantity.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyInt getQuantityBean() {
 		safeAccessQuantity();
 		return quantity;
@@ -137,6 +144,7 @@ public abstract class AAInterfaceEnd extends GenericCategory implements IBeanCat
 		return note.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyString getNoteBean() {
 		safeAccessNote();
 		return note;

--- a/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/ABusInterface.java
+++ b/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/ABusInterface.java
@@ -12,17 +12,21 @@ package de.dlr.sc.virsat.model.extension.cef.interfaces.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
-import de.dlr.sc.virsat.model.concept.list.TypeSafeReferencePropertyInstanceList;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.list.TypeSafeReferencePropertyBeanList;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.concept.list.IBeanList;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ArrayInstance;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
+import de.dlr.sc.virsat.model.concept.list.TypeSafeReferencePropertyInstanceList;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -37,6 +41,8 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ArrayInstance;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ABusInterface extends AInterface implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.interfaces.BusInterface";
@@ -96,6 +102,7 @@ public abstract class ABusInterface extends AInterface implements IBeanCategoryA
 			}
 		}
 		
+		@XmlElement
 		public IBeanList<BeanPropertyReference<AInterfaceEnd>> getConectedInterfaceEndsBean() {
 			safeAccessConectedInterfaceEndsBean();
 			return conectedInterfaceEndsBean;

--- a/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/ADataInterfaceEnd.java
+++ b/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/ADataInterfaceEnd.java
@@ -12,16 +12,22 @@ package de.dlr.sc.virsat.model.extension.cef.interfaces.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import org.eclipse.emf.common.command.Command;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ReferencePropertyInstance;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.common.command.Command;
+import de.dlr.sc.virsat.model.dvlm.json.ABeanObjectAdapter;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -36,6 +42,8 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ReferencePropert
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ADataInterfaceEnd extends AInterfaceEnd implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.interfaces.DataInterfaceEnd";
@@ -81,6 +89,8 @@ public abstract class ADataInterfaceEnd extends AInterfaceEnd implements IBeanCa
 		dataInterfaceType.setTypeInstance(propertyInstance);
 	}
 	
+	@XmlElement(nillable = true)
+	@XmlJavaTypeAdapter(ABeanObjectAdapter.class)
 	public DataInterfaceTypes getDataInterfaceType() {
 		safeAccessDataInterfaceType();
 		return dataInterfaceType.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/ADataInterfaceTypes.java
+++ b/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/ADataInterfaceTypes.java
@@ -12,17 +12,21 @@ package de.dlr.sc.virsat.model.extension.cef.interfaces.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import org.eclipse.emf.common.command.Command;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.common.command.Command;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -37,6 +41,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ADataInterfaceTypes extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.interfaces.DataInterfaceTypes";
@@ -98,6 +104,7 @@ public abstract class ADataInterfaceTypes extends GenericCategory implements IBe
 		return note.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyString getNoteBean() {
 		safeAccessNote();
 		return note;

--- a/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/AEquipmentDataParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/AEquipmentDataParameters.java
@@ -12,16 +12,20 @@ package de.dlr.sc.virsat.model.extension.cef.interfaces.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
 import de.dlr.sc.virsat.model.extension.cef.model.Parameter;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -36,6 +40,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AEquipmentDataParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.interfaces.EquipmentDataParameters";
@@ -89,6 +95,7 @@ public abstract class AEquipmentDataParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getDataDutyCycle() {
 		safeAccessDataDutyCycle();
 		return DataDutyCycle.getValue();
@@ -111,6 +118,7 @@ public abstract class AEquipmentDataParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getDataPerUnitOn() {
 		safeAccessDataPerUnitOn();
 		return DataPerUnitOn.getValue();
@@ -133,6 +141,7 @@ public abstract class AEquipmentDataParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getDataPerUnitStby() {
 		safeAccessDataPerUnitStby();
 		return DataPerUnitStby.getValue();
@@ -155,6 +164,7 @@ public abstract class AEquipmentDataParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getDataPerUnitOnWithMargin() {
 		safeAccessDataPerUnitOnWithMargin();
 		return DataPerUnitOnWithMargin.getValue();
@@ -177,6 +187,7 @@ public abstract class AEquipmentDataParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getDataPerUnitStbyWithMargin() {
 		safeAccessDataPerUnitStbyWithMargin();
 		return DataPerUnitStbyWithMargin.getValue();
@@ -199,6 +210,7 @@ public abstract class AEquipmentDataParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getDataPerUnitAvgWithMargin() {
 		safeAccessDataPerUnitAvgWithMargin();
 		return DataPerUnitAvgWithMargin.getValue();
@@ -221,6 +233,7 @@ public abstract class AEquipmentDataParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getDataAvgWithMargin() {
 		safeAccessDataAvgWithMargin();
 		return DataAvgWithMargin.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/APointToPointInterface.java
+++ b/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/APointToPointInterface.java
@@ -12,16 +12,22 @@ package de.dlr.sc.virsat.model.extension.cef.interfaces.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import org.eclipse.emf.common.command.Command;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ReferencePropertyInstance;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.common.command.Command;
+import de.dlr.sc.virsat.model.dvlm.json.ABeanObjectAdapter;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -36,6 +42,8 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ReferencePropert
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class APointToPointInterface extends AInterface implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.interfaces.PointToPointInterface";
@@ -82,6 +90,8 @@ public abstract class APointToPointInterface extends AInterface implements IBean
 		fromInterfaceEnd.setTypeInstance(propertyInstance);
 	}
 	
+	@XmlElement(nillable = true)
+	@XmlJavaTypeAdapter(ABeanObjectAdapter.class)
 	public AInterfaceEnd getFromInterfaceEnd() {
 		safeAccessFromInterfaceEnd();
 		return fromInterfaceEnd.getValue();
@@ -112,6 +122,8 @@ public abstract class APointToPointInterface extends AInterface implements IBean
 		toInterfceEnd.setTypeInstance(propertyInstance);
 	}
 	
+	@XmlElement(nillable = true)
+	@XmlJavaTypeAdapter(ABeanObjectAdapter.class)
 	public AInterfaceEnd getToInterfceEnd() {
 		safeAccessToInterfceEnd();
 		return toInterfceEnd.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/APowerInterfaceEnd.java
+++ b/de.dlr.sc.virsat.model.extension.cef.interfaces/src-gen/de/dlr/sc/virsat/model/extension/cef/interfaces/model/APowerInterfaceEnd.java
@@ -12,16 +12,20 @@ package de.dlr.sc.virsat.model.extension.cef.interfaces.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
+import javax.xml.bind.annotation.XmlRootElement;
+import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.common.command.Command;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloat;
-import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -36,6 +40,8 @@ import de.dlr.sc.virsat.model.dvlm.categories.Category;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class APowerInterfaceEnd extends AInterfaceEnd implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.interfaces.PowerInterfaceEnd";
@@ -104,6 +110,7 @@ public abstract class APowerInterfaceEnd extends AInterfaceEnd implements IBeanC
 		return voltageMin.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getVoltageMinBean() {
 		safeAccessVoltageMin();
 		return voltageMin;
@@ -140,6 +147,7 @@ public abstract class APowerInterfaceEnd extends AInterfaceEnd implements IBeanC
 		return voltageNominal.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getVoltageNominalBean() {
 		safeAccessVoltageNominal();
 		return voltageNominal;
@@ -176,6 +184,7 @@ public abstract class APowerInterfaceEnd extends AInterfaceEnd implements IBeanC
 		return voltageMax.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getVoltageMaxBean() {
 		safeAccessVoltageMax();
 		return voltageMax;

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ADocument.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ADocument.java
@@ -12,13 +12,16 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
 import org.eclipse.emf.common.util.URI;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
+import javax.xml.bind.annotation.XmlAccessType;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ResourcePropertyInstance;
 import org.eclipse.emf.edit.domain.EditingDomain;
@@ -26,6 +29,7 @@ import org.eclipse.emf.common.command.Command;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyResource;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -40,6 +44,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * Category to describe documents such as specifications
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ADocument extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.Document";
@@ -104,6 +110,7 @@ public abstract class ADocument extends GenericCategory implements IBeanCategory
 		return name.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyString getNameBean() {
 		safeAccessName();
 		return name;
@@ -135,6 +142,7 @@ public abstract class ADocument extends GenericCategory implements IBeanCategory
 		return note.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyString getNoteBean() {
 		safeAccessNote();
 		return note;
@@ -166,6 +174,7 @@ public abstract class ADocument extends GenericCategory implements IBeanCategory
 		return url.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyString getUrlBean() {
 		safeAccessUrl();
 		return url;
@@ -197,6 +206,7 @@ public abstract class ADocument extends GenericCategory implements IBeanCategory
 		return file.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyResource getFileBean() {
 		safeAccessFile();
 		return file;

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AEquipmentMassParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AEquipmentMassParameters.java
@@ -12,15 +12,19 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -35,6 +39,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AEquipmentMassParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.EquipmentMassParameters";
@@ -84,6 +90,7 @@ public abstract class AEquipmentMassParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassPerUnit() {
 		safeAccessMassPerUnit();
 		return massPerUnit.getValue();
@@ -106,6 +113,7 @@ public abstract class AEquipmentMassParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassTotal() {
 		safeAccessMassTotal();
 		return massTotal.getValue();
@@ -128,6 +136,7 @@ public abstract class AEquipmentMassParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassTotalWithMargin() {
 		safeAccessMassTotalWithMargin();
 		return massTotalWithMargin.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AEquipmentParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AEquipmentParameters.java
@@ -12,17 +12,21 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
+import javax.xml.bind.annotation.XmlRootElement;
+import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.common.command.Command;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloat;
-import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyInt;
 
 
@@ -38,6 +42,8 @@ import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyInt;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AEquipmentParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.EquipmentParameters";
@@ -105,6 +111,7 @@ public abstract class AEquipmentParameters extends GenericCategory implements IB
 		return marginMaturity.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getMarginMaturityBean() {
 		safeAccessMarginMaturity();
 		return marginMaturity;
@@ -141,6 +148,7 @@ public abstract class AEquipmentParameters extends GenericCategory implements IB
 		return unitQuantity.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyInt getUnitQuantityBean() {
 		safeAccessUnitQuantity();
 		return unitQuantity;

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AEquipmentPowerParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AEquipmentPowerParameters.java
@@ -12,15 +12,19 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -35,6 +39,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AEquipmentPowerParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.EquipmentPowerParameters";
@@ -89,6 +95,7 @@ public abstract class AEquipmentPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getActiveUnits() {
 		safeAccessActiveUnits();
 		return activeUnits.getValue();
@@ -111,6 +118,7 @@ public abstract class AEquipmentPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerDutyCycle() {
 		safeAccessPowerDutyCycle();
 		return powerDutyCycle.getValue();
@@ -133,6 +141,7 @@ public abstract class AEquipmentPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerPerUnitOn() {
 		safeAccessPowerPerUnitOn();
 		return PowerPerUnitOn.getValue();
@@ -155,6 +164,7 @@ public abstract class AEquipmentPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerPerUnitStby() {
 		safeAccessPowerPerUnitStby();
 		return PowerPerUnitStby.getValue();
@@ -177,6 +187,7 @@ public abstract class AEquipmentPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerPerUnitOnWithMargin() {
 		safeAccessPowerPerUnitOnWithMargin();
 		return PowerPerUnitOnWithMargin.getValue();
@@ -199,6 +210,7 @@ public abstract class AEquipmentPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerPerUnitStbyWithMargin() {
 		safeAccessPowerPerUnitStbyWithMargin();
 		return PowerPerUnitStbyWithMargin.getValue();
@@ -221,6 +233,7 @@ public abstract class AEquipmentPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerPerUnitAvgWithMargin() {
 		safeAccessPowerPerUnitAvgWithMargin();
 		return PowerPerUnitAvgWithMargin.getValue();
@@ -243,6 +256,7 @@ public abstract class AEquipmentPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerAvgWithMargin() {
 		safeAccessPowerAvgWithMargin();
 		return PowerAvgWithMargin.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AEquipmentTemperatureParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AEquipmentTemperatureParameters.java
@@ -12,15 +12,19 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -35,6 +39,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AEquipmentTemperatureParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.EquipmentTemperatureParameters";
@@ -85,6 +91,7 @@ public abstract class AEquipmentTemperatureParameters extends GenericCategory im
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getTemperatureNoOpsMax() {
 		safeAccessTemperatureNoOpsMax();
 		return temperatureNoOpsMax.getValue();
@@ -107,6 +114,7 @@ public abstract class AEquipmentTemperatureParameters extends GenericCategory im
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getTemperatureNoOpsMin() {
 		safeAccessTemperatureNoOpsMin();
 		return temperatureNoOpsMin.getValue();
@@ -129,6 +137,7 @@ public abstract class AEquipmentTemperatureParameters extends GenericCategory im
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getTemperatureOpsMax() {
 		safeAccessTemperatureOpsMax();
 		return temperatureOpsMax.getValue();
@@ -151,6 +160,7 @@ public abstract class AEquipmentTemperatureParameters extends GenericCategory im
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getTemperatureOpsMin() {
 		safeAccessTemperatureOpsMin();
 		return temperatureOpsMin.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AExcelCalculation.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AExcelCalculation.java
@@ -12,14 +12,17 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.list.TypeSafeReferencePropertyBeanList;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
 import org.eclipse.emf.common.util.URI;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.concept.list.IBeanList;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ArrayInstance;
+import javax.xml.bind.annotation.XmlAccessType;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ResourcePropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
@@ -29,6 +32,7 @@ import org.eclipse.emf.common.command.Command;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyResource;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -43,6 +47,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AExcelCalculation extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.ExcelCalculation";
@@ -106,6 +112,7 @@ public abstract class AExcelCalculation extends GenericCategory implements IBean
 		return excelFile.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyResource getExcelFileBean() {
 		safeAccessExcelFile();
 		return excelFile;
@@ -135,6 +142,7 @@ public abstract class AExcelCalculation extends GenericCategory implements IBean
 			}
 		}
 		
+		@XmlElement
 		public IBeanList<BeanPropertyReference<Parameter>> getFromVirSat2ExcelBean() {
 			safeAccessFromVirSat2ExcelBean();
 			return fromVirSat2ExcelBean;
@@ -164,6 +172,7 @@ public abstract class AExcelCalculation extends GenericCategory implements IBean
 			}
 		}
 		
+		@XmlElement
 		public IBeanList<BeanPropertyReference<Parameter>> getFromExcel2VirSatBean() {
 			safeAccessFromExcel2VirSatBean();
 			return fromExcel2VirSatBean;

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AParameter.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AParameter.java
@@ -12,14 +12,17 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.concept.list.IBeanList;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ArrayInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
+import javax.xml.bind.annotation.XmlAccessType;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.common.command.Command;
@@ -30,6 +33,7 @@ import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloat;
 import de.dlr.sc.virsat.model.concept.list.TypeSafeComposedPropertyInstanceList;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -44,6 +48,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AParameter extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.Parameter";
@@ -113,6 +119,7 @@ public abstract class AParameter extends GenericCategory implements IBeanCategor
 		return defaultValue.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getDefaultValueBean() {
 		safeAccessDefaultValue();
 		return defaultValue;
@@ -142,6 +149,7 @@ public abstract class AParameter extends GenericCategory implements IBeanCategor
 		}
 	}
 	
+	@XmlElement
 	public IBeanList<BeanPropertyComposed<Value>> getModeValuesBean() {
 		safeAccessModeValuesBean();
 		return modeValuesBean;
@@ -171,6 +179,7 @@ public abstract class AParameter extends GenericCategory implements IBeanCategor
 		}
 	}
 	
+	@XmlElement
 	public IBeanList<BeanPropertyComposed<ParameterRange>> getRangeValuesBean() {
 		safeAccessRangeValuesBean();
 		return rangeValuesBean;
@@ -202,6 +211,7 @@ public abstract class AParameter extends GenericCategory implements IBeanCategor
 		return note.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyString getNoteBean() {
 		safeAccessNote();
 		return note;

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AParameterRange.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AParameterRange.java
@@ -12,17 +12,21 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
+import javax.xml.bind.annotation.XmlRootElement;
+import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.common.command.Command;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloat;
-import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -37,6 +41,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AParameterRange extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.ParameterRange";
@@ -104,6 +110,7 @@ public abstract class AParameterRange extends GenericCategory implements IBeanCa
 		return minValue.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getMinValueBean() {
 		safeAccessMinValue();
 		return minValue;
@@ -140,6 +147,7 @@ public abstract class AParameterRange extends GenericCategory implements IBeanCa
 		return maxValue.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getMaxValueBean() {
 		safeAccessMaxValue();
 		return maxValue;

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASubSystemMassParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASubSystemMassParameters.java
@@ -12,15 +12,19 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -35,6 +39,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ASubSystemMassParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.SubSystemMassParameters";
@@ -85,6 +91,7 @@ public abstract class ASubSystemMassParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassTotal() {
 		safeAccessMassTotal();
 		return massTotal.getValue();
@@ -107,6 +114,7 @@ public abstract class ASubSystemMassParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassTotalWithMargin() {
 		safeAccessMassTotalWithMargin();
 		return massTotalWithMargin.getValue();
@@ -129,6 +137,7 @@ public abstract class ASubSystemMassParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassMarginPercentage() {
 		safeAccessMassMarginPercentage();
 		return massMarginPercentage.getValue();
@@ -151,6 +160,7 @@ public abstract class ASubSystemMassParameters extends GenericCategory implement
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassMargin() {
 		safeAccessMassMargin();
 		return massMargin.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASubSystemPowerParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASubSystemPowerParameters.java
@@ -12,15 +12,19 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -35,6 +39,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ASubSystemPowerParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.SubSystemPowerParameters";
@@ -83,6 +89,7 @@ public abstract class ASubSystemPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerAvgWithMargin() {
 		safeAccessPowerAvgWithMargin();
 		return powerAvgWithMargin.getValue();
@@ -105,6 +112,7 @@ public abstract class ASubSystemPowerParameters extends GenericCategory implemen
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerEnergyWithMargin() {
 		safeAccessPowerEnergyWithMargin();
 		return powerEnergyWithMargin.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASystemMassParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASystemMassParameters.java
@@ -12,15 +12,19 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -35,6 +39,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ASystemMassParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.SystemMassParameters";
@@ -89,6 +95,7 @@ public abstract class ASystemMassParameters extends GenericCategory implements I
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassLaunch() {
 		safeAccessMassLaunch();
 		return massLaunch.getValue();
@@ -111,6 +118,7 @@ public abstract class ASystemMassParameters extends GenericCategory implements I
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassTotal() {
 		safeAccessMassTotal();
 		return massTotal.getValue();
@@ -133,6 +141,7 @@ public abstract class ASystemMassParameters extends GenericCategory implements I
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassTotalWithMargin() {
 		safeAccessMassTotalWithMargin();
 		return massTotalWithMargin.getValue();
@@ -155,6 +164,7 @@ public abstract class ASystemMassParameters extends GenericCategory implements I
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassTotalWithMarginWithSystemMargin() {
 		safeAccessMassTotalWithMarginWithSystemMargin();
 		return massTotalWithMarginWithSystemMargin.getValue();
@@ -177,6 +187,7 @@ public abstract class ASystemMassParameters extends GenericCategory implements I
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassAdapter() {
 		safeAccessMassAdapter();
 		return massAdapter.getValue();
@@ -199,6 +210,7 @@ public abstract class ASystemMassParameters extends GenericCategory implements I
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassPropellant() {
 		safeAccessMassPropellant();
 		return massPropellant.getValue();
@@ -221,6 +233,7 @@ public abstract class ASystemMassParameters extends GenericCategory implements I
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassLaunchMax() {
 		safeAccessMassLaunchMax();
 		return massLaunchMax.getValue();
@@ -243,6 +256,7 @@ public abstract class ASystemMassParameters extends GenericCategory implements I
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getMassBuffer() {
 		safeAccessMassBuffer();
 		return massBuffer.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASystemMode.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASystemMode.java
@@ -12,17 +12,21 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import org.eclipse.emf.common.command.Command;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.common.command.Command;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -37,6 +41,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ASystemMode extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.SystemMode";
@@ -98,6 +104,7 @@ public abstract class ASystemMode extends GenericCategory implements IBeanCatego
 		return note.getValue();
 	}
 	
+	@XmlElement
 	public BeanPropertyString getNoteBean() {
 		safeAccessNote();
 		return note;

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASystemParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASystemParameters.java
@@ -12,10 +12,13 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.common.command.Command;
@@ -25,6 +28,7 @@ import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloat;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -39,6 +43,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ASystemParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.SystemParameters";
@@ -106,6 +112,7 @@ public abstract class ASystemParameters extends GenericCategory implements IBean
 		return systemMargin.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getSystemMarginBean() {
 		safeAccessSystemMargin();
 		return systemMargin;
@@ -123,6 +130,7 @@ public abstract class ASystemParameters extends GenericCategory implements IBean
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getModeDuration() {
 		safeAccessModeDuration();
 		return modeDuration.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASystemPowerParameters.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/ASystemPowerParameters.java
@@ -12,15 +12,19 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -35,6 +39,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class ASystemPowerParameters extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.SystemPowerParameters";
@@ -85,6 +91,7 @@ public abstract class ASystemPowerParameters extends GenericCategory implements 
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerAvgWithMargin() {
 		safeAccessPowerAvgWithMargin();
 		return powerAvgWithMargin.getValue();
@@ -107,6 +114,7 @@ public abstract class ASystemPowerParameters extends GenericCategory implements 
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerAvgWithSystemMargin() {
 		safeAccessPowerAvgWithSystemMargin();
 		return powerAvgWithSystemMargin.getValue();
@@ -129,6 +137,7 @@ public abstract class ASystemPowerParameters extends GenericCategory implements 
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerEnergyWithMargin() {
 		safeAccessPowerEnergyWithMargin();
 		return powerEnergyWithMargin.getValue();
@@ -151,6 +160,7 @@ public abstract class ASystemPowerParameters extends GenericCategory implements 
 		}
 	}
 	
+	@XmlElement(nillable = true)
 	public Parameter getPowerEnergyWithSystemMargin() {
 		safeAccessPowerEnergyWithSystemMargin();
 		return powerEnergyWithSystemMargin.getValue();

--- a/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AValue.java
+++ b/de.dlr.sc.virsat.model.extension.cef/src-gen/de/dlr/sc/virsat/model/extension/cef/model/AValue.java
@@ -12,19 +12,25 @@ package de.dlr.sc.virsat.model.extension.cef.model;
 // *****************************************************************
 // * Import Statements
 // *****************************************************************
+import javax.xml.bind.annotation.XmlAccessorType;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
+import javax.xml.bind.annotation.XmlRootElement;
 import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import javax.xml.bind.annotation.XmlAccessType;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ReferencePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.common.command.Command;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
+import de.dlr.sc.virsat.model.dvlm.json.ABeanObjectAdapter;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloat;
 import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
+import javax.xml.bind.annotation.XmlElement;
 
 
 // *****************************************************************
@@ -39,6 +45,8 @@ import de.dlr.sc.virsat.model.ext.core.model.GenericCategory;
  * 
  * 
  */	
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.NONE)
 public abstract class AValue extends GenericCategory implements IBeanCategoryAssignment {
 
 	public static final String FULL_QUALIFIED_CATEGORY_NAME = "de.dlr.sc.virsat.model.extension.cef.Value";
@@ -106,6 +114,7 @@ public abstract class AValue extends GenericCategory implements IBeanCategoryAss
 		return value.isSet();
 	}
 	
+	@XmlElement
 	public BeanPropertyFloat getValueBean() {
 		safeAccessValue();
 		return value;
@@ -121,6 +130,8 @@ public abstract class AValue extends GenericCategory implements IBeanCategoryAss
 		mode.setTypeInstance(propertyInstance);
 	}
 	
+	@XmlElement(nillable = true)
+	@XmlJavaTypeAdapter(ABeanObjectAdapter.class)
 	public SystemMode getMode() {
 		safeAccessMode();
 		return mode.getValue();

--- a/de.dlr.sc.virsat.model.extension.cefx.ui/src/de/dlr/sc/virsat/model/extension/cefx/ui/masssummary/UiSnippetElements.java
+++ b/de.dlr.sc.virsat.model.extension.cefx.ui/src/de/dlr/sc/virsat/model/extension/cefx/ui/masssummary/UiSnippetElements.java
@@ -224,14 +224,14 @@ public class UiSnippetElements extends AUiSnippetTable {
 	 * @return the BeanCategory for the Visualization or null if it was not found
 	 */
 	private SystemMassParameters getSystemMassParameters(BeanStructuralElementInstance beanSei) {
-		IBeanStructuralElementInstance parentBeanSei = beanSei.getParentSeiBean(); 
+		IBeanStructuralElementInstance parentBeanSei = beanSei.getParent(); 
 		
 		while (parentBeanSei != null) {
 			SystemMassParameters systemMassParameters = parentBeanSei.getFirst(SystemMassParameters.class);
 			if (systemMassParameters != null) {
 				return systemMassParameters;
 			}
-			parentBeanSei = parentBeanSei.getParentSeiBean();
+			parentBeanSei = parentBeanSei.getParent();
 		}
 		
 		return null;


### PR DESCRIPTION
- Regenerated code: 
  - bean cas now contain XMLAnnotations required for the REST API
  - removed trailing whitespaces in the target files
- Fixed renamed Bean API function getParentSeiBean to getParent