### PR TITLE
Task #177 Fix level checking in product tree

### DIFF
--- a/de.dlr.sc.virsat.model.extension.cefx.test/src/de/dlr/sc/virsat/model/extension/cefx/hierarchy/CefxHierarchyLevelCheckerTest.java
+++ b/de.dlr.sc.virsat.model.extension.cefx.test/src/de/dlr/sc/virsat/model/extension/cefx/hierarchy/CefxHierarchyLevelCheckerTest.java
@@ -35,6 +35,7 @@ import de.dlr.sc.virsat.model.extension.cefx.model.SystemParameters;
 import de.dlr.sc.virsat.model.extension.cefx.model.SystemPowerParameters;
 import de.dlr.sc.virsat.model.extension.ps.model.ConfigurationTree;
 import de.dlr.sc.virsat.model.extension.ps.model.ElementConfiguration;
+import de.dlr.sc.virsat.model.extension.ps.model.ElementDefinition;
 
 /**
  * Test class for CefxHierarchyLevelChecker
@@ -88,6 +89,20 @@ public class CefxHierarchyLevelCheckerTest extends AConceptTestCase {
 		// third can be any level
 		assertCanAddSystemCAs(ec3, true);
 		assertCanAddSubSystemCAs(ec3, true);
+		assertCanAddEquipmentCAs(ec3, true);
+	}
+	
+	@Test
+	public void testElementsInProductTree() {
+		ElementDefinition ec1 = new ElementDefinition(conceptPS);
+		ElementDefinition ec2 = new ElementDefinition(conceptPS);
+		ElementDefinition ec3 = new ElementDefinition(conceptPS);
+		ec1.add(ec2);
+		ec2.add(ec3);
+		
+		// In product tree everything's possible :)
+		assertCanAddEquipmentCAs(ec1, true);
+		assertCanAddEquipmentCAs(ec2, true);
 		assertCanAddEquipmentCAs(ec3, true);
 	}
 

--- a/de.dlr.sc.virsat.model.extension.cefx/src/de/dlr/sc/virsat/model/extension/cefx/hierarchy/CefxHierarchyLevelChecker.java
+++ b/de.dlr.sc.virsat.model.extension.cefx/src/de/dlr/sc/virsat/model/extension/cefx/hierarchy/CefxHierarchyLevelChecker.java
@@ -96,7 +96,6 @@ public class CefxHierarchyLevelChecker {
 	 * @return true if a system related category assignment can be added
 	 */
 	public boolean canAddSystemCategory(IBeanStructuralElementInstance bean) {
-		
 		try {
 			return levelChecker.checkApplicable(bean, systemLevel);
 		} catch (IllegalArgumentException e) {
@@ -115,7 +114,6 @@ public class CefxHierarchyLevelChecker {
 	 * @return true if a sub system related category assignment can be added
 	 */
 	public boolean canAddSubSystemCategory(IBeanStructuralElementInstance bean) {
-		
 		try {
 			return levelChecker.checkApplicable(bean, subSystemLevel);
 		} catch (IllegalArgumentException e) {

--- a/de.dlr.sc.virsat.model.extension.cefx/src/de/dlr/sc/virsat/model/extension/cefx/hierarchy/CefxHierarchyLevelChecker.java
+++ b/de.dlr.sc.virsat.model.extension.cefx/src/de/dlr/sc/virsat/model/extension/cefx/hierarchy/CefxHierarchyLevelChecker.java
@@ -26,6 +26,7 @@ import de.dlr.sc.virsat.model.extension.cefx.model.SubSystemPowerParameters;
 import de.dlr.sc.virsat.model.extension.cefx.model.SystemMassParameters;
 import de.dlr.sc.virsat.model.extension.cefx.model.SystemParameters;
 import de.dlr.sc.virsat.model.extension.cefx.model.SystemPowerParameters;
+import de.dlr.sc.virsat.model.extension.ps.model.ElementDefinition;
 
 /**
  * Class to check the model tree hierarchy of SYSTEM, SUBSYSTEM and EQUIPMENT
@@ -65,6 +66,13 @@ public class CefxHierarchyLevelChecker {
 	 */
 	public boolean canAdd(IBeanStructuralElementInstance bean,
 			Class<? extends IBeanCategoryAssignment> categoryBeanClass) {
+		
+		// In product tree levels don't make sense
+		if (bean.getStructuralElementInstance().getType().getFullQualifiedName().equals(ElementDefinition.FULL_QUALIFIED_STRUCTURAL_ELEMENT_NAME)
+				&& equipmentLevel.categoryBelongsToLevel(categoryBeanClass)) {
+			return true;
+		}
+				
 		try {
 			for (IHierarchyLevel level : levelChecker.getApplicableLevels(bean)) {
 				if (((CefxHierarchyLevel) level).categoryBelongsToLevel(categoryBeanClass)) {
@@ -88,6 +96,7 @@ public class CefxHierarchyLevelChecker {
 	 * @return true if a system related category assignment can be added
 	 */
 	public boolean canAddSystemCategory(IBeanStructuralElementInstance bean) {
+		
 		try {
 			return levelChecker.checkApplicable(bean, systemLevel);
 		} catch (IllegalArgumentException e) {
@@ -106,6 +115,7 @@ public class CefxHierarchyLevelChecker {
 	 * @return true if a sub system related category assignment can be added
 	 */
 	public boolean canAddSubSystemCategory(IBeanStructuralElementInstance bean) {
+		
 		try {
 			return levelChecker.checkApplicable(bean, subSystemLevel);
 		} catch (IllegalArgumentException e) {
@@ -124,6 +134,12 @@ public class CefxHierarchyLevelChecker {
 	 * @return true if a equipment related category assignment can be added
 	 */
 	public boolean canAddEquipmentCategory(IBeanStructuralElementInstance bean) {
+		
+		// In product tree levels don't make sense
+		if (bean.getStructuralElementInstance().getType().getFullQualifiedName().equals(ElementDefinition.FULL_QUALIFIED_STRUCTURAL_ELEMENT_NAME)) {
+			return true;
+		}
+		
 		try {
 			return levelChecker.checkApplicable(bean, equipmentLevel);
 		} catch (IllegalArgumentException e) {


### PR DESCRIPTION
Closes #177 

Fix level checker for product tree... 

You should set the option to 'igonre white space changes' in the changes viewer... Otherwise you can't really see the difference in the file... Apperently the white spaces where broken before